### PR TITLE
Add missing factor of 0.5 to flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Set `Formulation.JONES_DIRECT_FOURIER` as the default formulation for all eigensolve functions in `fmm` module.
 - Remove redundant definitions of Poynting flux calculations and use `fields.time_average_z_poynting_flux` instead.
+- Include a missing factor of 0.5 in the flux returned by `amplitude_poynting_flux`, `directional_poynting_flux`, `eigenmode_poynting_flux`, and `time_average_z_poynting_flux` functions. The result is that the time-average Poynting flux is computed from the fields by, `sz = 0.5 * real(ex * hy.conj() - ey * hx.conj())`, as it should be. The factor of 0.5 is also missing from S4, GRCWA, and the [S4 reference paper](https://web.stanford.edu/group/fan/publication/Liu_ComputerPhysicsCommunications_183_2233_2012.pdf#page=3.75) (section 5.1), which is how it came to exist in this code.
 
 ## 0.14.4 (February 25, 2025)
 - Set `Formulation.JONES_DIRECT_FOURIER` as the default formulation for `fmm.eigensolve_isotropic_media`.

--- a/src/fmmax/fields.py
+++ b/src/fmmax/fields.py
@@ -261,7 +261,7 @@ def eigenmode_poynting_flux(
     alpha_e = _poynting_flux_a_matrix(layer_solve_result)
     # Note the prefactor of 0.25 (0.5**2) instead of 0.5, as is seen in [2012 Liu].
     # The additional factor comes from `Re(x) = 0.5 * (x + x.conj())`, which is
-    # omitted in that reference.s
+    # omitted in that reference.
     s_eigenmode = jnp.asarray(0.25) * (
         jnp.conj(alpha_e) * alpha_h + jnp.conj(alpha_h) * alpha_e
     )

--- a/src/fmmax/fields.py
+++ b/src/fmmax/fields.py
@@ -144,11 +144,14 @@ def amplitude_poynting_flux(
     alpha_e = A @ forward_amplitude
     beta_e = A @ backward_amplitude
 
-    s_forward = jnp.asarray(0.5, dtype=forward_amplitude.dtype) * (
+    # Note the prefactor of 0.25 (0.5**2) instead of 0.5, as is seen in [2012 Liu].
+    # The additional factor comes from `Re(x) = 0.5 * (x + x.conj())`, which is
+    # omitted in that reference.
+    s_forward = jnp.asarray(0.25, dtype=forward_amplitude.dtype) * (
         (jnp.conj(alpha_e) * alpha_h + jnp.conj(alpha_h) * alpha_e)
         + (jnp.conj(beta_h) * alpha_e - jnp.conj(beta_e) * alpha_h)
     )
-    s_backward = jnp.asarray(0.5, dtype=forward_amplitude.dtype) * (
+    s_backward = jnp.asarray(0.25, dtype=forward_amplitude.dtype) * (
         -(jnp.conj(beta_e) * beta_h + jnp.conj(beta_h) * beta_e)
         + jnp.conj(jnp.conj(beta_h) * alpha_e - jnp.conj(beta_e) * alpha_h)
     )
@@ -216,7 +219,10 @@ def directional_poynting_flux(
         a_subset: jnp.ndarray,
         b_subset: jnp.ndarray,
     ) -> jnp.ndarray:
-        return jnp.asarray(0.5) * (
+        # Note the prefactor of 0.25 (0.5**2) instead of 0.5, as is seen in [2012 Liu].
+        # The additional factor comes from `Re(x) = 0.5 * (x + x.conj())`, which is
+        # omitted in that reference.
+        return jnp.asarray(0.25) * (
             jnp.conj(A @ (a_total - b_total)) * (phi @ (a_subset + b_subset))
             + jnp.conj(phi @ (a_total + b_total)) * (A @ (a_subset - b_subset))
         )
@@ -253,7 +259,10 @@ def eigenmode_poynting_flux(
     """
     alpha_h = layer_solve_result.eigenvectors
     alpha_e = _poynting_flux_a_matrix(layer_solve_result)
-    s_eigenmode = jnp.asarray(0.5) * (
+    # Note the prefactor of 0.25 (0.5**2) instead of 0.5, as is seen in [2012 Liu].
+    # The additional factor comes from `Re(x) = 0.5 * (x + x.conj())`, which is
+    # omitted in that reference.s
+    s_eigenmode = jnp.asarray(0.25) * (
         jnp.conj(alpha_e) * alpha_h + jnp.conj(alpha_h) * alpha_e
     )
     flux = jnp.sum(jnp.real(s_eigenmode), axis=-2)
@@ -1061,4 +1070,4 @@ def time_average_z_poynting_flux(
     """
     ex, ey, _ = electric_fields
     hx, hy, _ = magnetic_fields
-    return jnp.real(ex * jnp.conj(hy) - ey * jnp.conj(hx))
+    return 0.5 * jnp.real(ex * jnp.conj(hy) - ey * jnp.conj(hx))

--- a/tests/fmmax/test_fields.py
+++ b/tests/fmmax/test_fields.py
@@ -730,7 +730,7 @@ class TimeAveragePoyntingFluxTest(unittest.TestCase):
 
 
 class PlaneWaveFluxMatchesExpected(unittest.TestCase):
-    def test(self):
+    def test_forward_flux(self):
         solve_result = fmm.eigensolve_isotropic_media(
             wavelength=jnp.asarray(0.55),
             in_plane_wavevector=jnp.zeros((2,)),
@@ -747,7 +747,49 @@ class PlaneWaveFluxMatchesExpected(unittest.TestCase):
             layer_solve_result=solve_result,
         )
         expected_s = 0.5 * (ex * hy.conj() - ey * hx.conj()).real
-        s_fwd, s_bwd = fields.amplitude_poynting_flux(fwd, bwd, solve_result)
 
-        onp.testing.assert_allclose(onp.sum(s_fwd), expected_s)
-        onp.testing.assert_allclose(onp.sum(s_bwd), 0.0)
+        with self.subTest("amplitude_poynting_flux"):
+            s_fwd, s_bwd = fields.amplitude_poynting_flux(fwd, bwd, solve_result)
+            onp.testing.assert_allclose(onp.sum(s_fwd), expected_s)
+            onp.testing.assert_allclose(onp.sum(s_bwd), 0.0)
+
+        with self.subTest("directional_poynting_flux"):
+            s_fwd, s_bwd = fields.directional_poynting_flux(fwd, bwd, solve_result)
+            onp.testing.assert_allclose(onp.sum(s_fwd), expected_s)
+            onp.testing.assert_allclose(onp.sum(s_bwd), 0.0)
+
+        with self.subTest("eigenmode_poynting_flux"):
+            s = fields.eigenmode_poynting_flux(solve_result)
+            onp.testing.assert_allclose(s, onp.asarray([0.5, 0.5]), rtol=1e-6)
+
+    def test_backward_flux(self):
+        solve_result = fmm.eigensolve_isotropic_media(
+            wavelength=jnp.asarray(0.55),
+            in_plane_wavevector=jnp.zeros((2,)),
+            primitive_lattice_vectors=basis.LatticeVectors(basis.X, basis.Y),
+            permittivity=jnp.ones((1, 1), dtype=jnp.complex64),
+            expansion=basis.Expansion(onp.asarray([[0, 0]])),
+        )
+
+        bwd = jnp.zeros((2, 1), jnp.complex64).at[0, 0].set(1)
+        fwd = jnp.zeros_like(bwd)
+        (ex, ey, ez), (hx, hy, hz) = fields.fields_from_wave_amplitudes(
+            forward_amplitude=fwd,
+            backward_amplitude=bwd,
+            layer_solve_result=solve_result,
+        )
+        expected_s = 0.5 * (ex * hy.conj() - ey * hx.conj()).real
+
+        with self.subTest("amplitude_poynting_flux"):
+            s_fwd, s_bwd = fields.amplitude_poynting_flux(fwd, bwd, solve_result)
+            onp.testing.assert_allclose(onp.sum(s_fwd), 0.0)
+            onp.testing.assert_allclose(onp.sum(s_bwd), expected_s)
+
+        with self.subTest("directional_poynting_flux"):
+            s_fwd, s_bwd = fields.directional_poynting_flux(fwd, bwd, solve_result)
+            onp.testing.assert_allclose(onp.sum(s_fwd), 0.0)
+            onp.testing.assert_allclose(onp.sum(s_bwd), expected_s)
+
+        with self.subTest("eigenmode_poynting_flux"):
+            s = fields.eigenmode_poynting_flux(solve_result)
+            onp.testing.assert_allclose(s, onp.asarray([0.5, 0.5]), rtol=1e-6)


### PR DESCRIPTION
Previously, the flux values returned by `amplitude_poynting_flux`, `directional_poynting_flux`, and `eigenmode_poynting_flux` were off by a factor of 2, arising from a missing factor of 0.5 in the S4 paper, section 5.1. To compensate, the function `time_average_z_poynting_flux` scaled the flux by 2, so that the flux values computed by these two methods would agree.

After digging into this and identifying the original source of the error, we correct the flux-calculating functions, so that they are in agreement and contain no missing or additional factors.