### PR TITLE
Make solve result fields full rank

### DIFF
--- a/src/fmmax/basis.py
+++ b/src/fmmax/basis.py
@@ -157,11 +157,11 @@ def _reciprocal(lattice_vectors: LatticeVectors) -> LatticeVectors:
     cross_product = _cross_product(lattice_vectors.u, lattice_vectors.v)
     uprime = (
         jnp.stack([lattice_vectors.v[..., 1], -lattice_vectors.v[..., 0]], axis=-1)
-        / cross_product
+        / cross_product[..., jnp.newaxis]
     )
     vprime = (
         jnp.stack([-lattice_vectors.u[..., 1], lattice_vectors.u[..., 0]], axis=-1)
-        / cross_product
+        / cross_product[..., jnp.newaxis]
     )
     return LatticeVectors(u=uprime, v=vprime)
 
@@ -304,12 +304,16 @@ def transverse_wavevectors(
     """
     reciprocal_vectors = primitive_lattice_vectors.reciprocal
     kx = in_plane_wavevector[..., 0, jnp.newaxis] + 2 * jnp.pi * (
-        expansion.basis_coefficients[:, 0] * reciprocal_vectors.u[..., 0]
-        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[..., 0]
+        expansion.basis_coefficients[
+            :,
+            0,
+        ]
+        * reciprocal_vectors.u[..., 0, jnp.newaxis]
+        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[..., 0, jnp.newaxis]
     )
     ky = in_plane_wavevector[..., 1, jnp.newaxis] + 2 * jnp.pi * (
-        expansion.basis_coefficients[:, 0] * reciprocal_vectors.u[..., 1]
-        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[..., 1]
+        expansion.basis_coefficients[:, 0] * reciprocal_vectors.u[..., 1, jnp.newaxis]
+        + expansion.basis_coefficients[:, 1] * reciprocal_vectors.v[..., 1, jnp.newaxis]
     )
     return jnp.stack([kx, ky], axis=-1)
 

--- a/src/fmmax/fields.py
+++ b/src/fmmax/fields.py
@@ -793,10 +793,12 @@ def stack_fields_3d_auto_grid(
         The electric and magnetic fields and grid coordinates, ``(ef, hf, (x, y, z))``.
     """
     primitive_lattice_vectors = layer_solve_results[0].primitive_lattice_vectors
-    grid_shape = (
-        int(jnp.round(jnp.linalg.norm(primitive_lattice_vectors.u) / grid_spacing)),
-        int(jnp.round(jnp.linalg.norm(primitive_lattice_vectors.v) / grid_spacing)),
-    )
+
+    u = primitive_lattice_vectors.u
+    v = primitive_lattice_vectors.v
+    udim = jnp.amax(jnp.sqrt(u[..., 0] ** 2 + u[..., 1] ** 2)) / grid_spacing
+    vdim = jnp.amax(jnp.sqrt(v[..., 0] ** 2 + v[..., 1] ** 2)) / grid_spacing
+    grid_shape = int(jnp.around(udim)), int(jnp.around(vdim))
 
     layer_znum = tuple([int(jnp.round(t / grid_spacing)) for t in layer_thicknesses])
 

--- a/tests/fmmax/test_fields.py
+++ b/tests/fmmax/test_fields.py
@@ -179,8 +179,12 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
             shape=(20, 20),
             num_unit_cells=(1, 1),
         )
+        # Remove the batch dimension from the coordinates.
+        if x.ndim == 3:
+            x = x[0, ...]
+            y = y[0, ...]
         with self.subTest("xy on a square grid"):
-            efield, hfield, (x, y) = fields.fields_on_coordinates(
+            efield, hfield, _ = fields.fields_on_coordinates(
                 electric_field=(ex, ey, ez),
                 magnetic_field=(hx, hy, hz),
                 layer_solve_result=layer_solve_result,
@@ -239,7 +243,10 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
             grid_shape=(20, 20),
             num_unit_cells=(1, 1),
         )
-
+        # Remove the batch dimension from the coordinates.
+        if x.ndim == 3:
+            x = x[0, ...]
+            y = y[0, ...]
         with self.subTest("xy on a square grid"):
             efield, hfield, _ = fields.layer_fields_3d_on_coordinates(
                 forward_amplitude_start=fwd_amplitude_start,
@@ -283,7 +290,7 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
         ab = fields.stack_amplitudes_interior(
             s_matrices_interior, forward_amplitude_0_start, backward_amplitude_N_end
         )
-        expected_efield, expected_hfield, (x, y, z) = fields.stack_fields_3d(
+        expected_efield, expected_hfield, (x, y, _) = fields.stack_fields_3d(
             amplitudes_interior=ab,
             layer_solve_results=layer_solve_results,
             layer_thicknesses=thicknesses,
@@ -291,7 +298,11 @@ class FieldsOnCoordinatesTest(unittest.TestCase):
             grid_shape=(10, 10),
             num_unit_cells=(1, 1),
         )
-        efield, hfield, (x, y, z) = fields.stack_fields_3d_on_coordinates(
+        # Remove the batch dimension from the coordinates.
+        if x.ndim == 3:
+            x = x[0, ...]
+            y = y[0, ...]
+        efield, hfield, _ = fields.stack_fields_3d_on_coordinates(
             amplitudes_interior=ab,
             layer_solve_results=layer_solve_results,
             layer_thicknesses=thicknesses,

--- a/tests/fmmax/test_fmm.py
+++ b/tests/fmmax/test_fmm.py
@@ -593,11 +593,11 @@ class LayerSolveResultInputValidationTest(unittest.TestCase):
         )
         num = expansion.num_terms
         kwargs = {
-            "wavelength": jnp.ones((3, 1, 1)),
-            "in_plane_wavevector": jnp.ones((1, 4, 5, 2)),
+            "wavelength": jnp.ones((3, 4, 5)),
+            "in_plane_wavevector": jnp.ones((3, 4, 5, 2)),
             "primitive_lattice_vectors": basis.LatticeVectors(
-                u=basis.X * jnp.ones((1, 1, 1, 2)),
-                v=basis.Y * jnp.ones((1, 1, 1, 2)),
+                u=basis.X * jnp.ones((3, 4, 5, 2)),
+                v=basis.Y * jnp.ones((3, 4, 5, 2)),
             ),
             "expansion": expansion,
             "eigenvalues": jnp.ones((3, 4, 5, 2 * num)),

--- a/tests/fmmax/test_fresnel.py
+++ b/tests/fmmax/test_fresnel.py
@@ -81,10 +81,10 @@ class FresnelComparisonTest(unittest.TestCase):
         )
 
         solve_result_ambient = eigensolve_fn(
-            permittivity=jnp.asarray(n_ambient, dtype=complex) ** 2
+            permittivity=jnp.asarray([[n_ambient]], dtype=complex) ** 2
         )
         solve_result_substrate = eigensolve_fn(
-            permittivity=jnp.asarray(n_substrate, dtype=complex) ** 2
+            permittivity=jnp.asarray([[n_substrate]], dtype=complex) ** 2
         )
 
         layer_solve_results = (solve_result_ambient, solve_result_substrate)

--- a/tests/fmmax/test_sources.py
+++ b/tests/fmmax/test_sources.py
@@ -384,8 +384,8 @@ class InternalSourcesTest(unittest.TestCase):
             shape=(21, 21),
             num_unit_cells=brillouin_grid_shape,
         )
-        x = jnp.squeeze(x)  # Remove batch dimensions from BZ grid.
-        y = jnp.squeeze(y)
+        x = x[0, 0, :, :]  # Remove batch dimensions from BZ grid.
+        y = y[0, 0, :, :]
 
         # Perform Brillouin zone integration and compute magnetic field magnitude.
         hfield = jnp.mean(jnp.asarray(hfield), axis=(1, 2))


### PR DESCRIPTION
Broadcast all the attributes of the `LayerSolveResult` so they have the full batch shape.  Changes needed throughout, particularly to accommodate lattice vectors with batch dimensions. It's not clear that the full rank shape should be enforced, but it should at least be accommodated, and so some of the changes here could adopted in a separate PR.