### PR TITLE
Unit cell coordinates inside unit cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - Update Brillouin zone wavevector generation for even-sized grids so that `(0, 0)` is always included.
 - Ensure dtype is preserved in `farfield._unflatten`.
+- Update unit cell coordinates and fft functions so that an array defined on the unit cell has elements with values for pixel centers, rather than pixel lower-left corners.
 
 ## 1.3.0 (April 24, 2025)
 - Add permittivity shape validation to eigensolve functions.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Our support of anisotropic, magnetic materials allows modeling of uniaxial perfe
 - The speed of light, vacuum permittivity, and vacuum permeability are all 1.
 - Fields evolve in time as $\exp(-i \omega t)$.
 - If $\mathbf{u}$ and $\mathbf{v}$ are the primitive lattice vectors, the unit cell is defined by the parallelogram with vertices at $\mathbf{0}$, $\mathbf{u}$, $\mathbf{u} + \mathbf{v}$, and $\mathbf{v}$.
-- For quantities defined on a grid (such as the permittivity distribution of a patterned layer) the value at grid index (0, 0) corresponds to the value at physical location $\mathbf{0}$.
+- For quantities defined on a grid (such as the permittivity distribution of a patterned layer) the value at grid index (0, 0) corresponds to the value at physical location $\mathbf{du} / 2 + \mathbf{dv} / 2$.
 - The scattering matrix block $\mathbf{S}_{11}$ relates incident and transmitted forward-going fields, and other blocks have corresponding definitions. This differs from the convention e.g. in photonic integrated circuits.
 
 ## Batching

--- a/examples/crystal.py
+++ b/examples/crystal.py
@@ -404,7 +404,9 @@ def simulate_crystal_with_gaussian_beam(
         backward_amplitude_N_end=jnp.zeros_like(fwd_amplitude),
     )
     # Coordinates where fields are to be evaluated.
-    x = jnp.arange(0, pitch * brillouin_grid_shape[0], resolution_fields)
+    x = jnp.arange(
+        0.5 * resolution_fields, pitch * brillouin_grid_shape[0], resolution_fields
+    )
     y = jnp.ones_like(x) * pitch * brillouin_grid_shape[1] / 2
     (ex, ey, ez), (hx, hy, hz), (x, y, z) = fmmax.stack_fields_3d_on_coordinates(
         amplitudes_interior=amplitudes_interior,
@@ -447,8 +449,8 @@ def unit_cell_pattern(
 ) -> jnp.ndarray:
     """Defines the pattern of the photonic crystal."""
     x, y = jnp.meshgrid(
-        jnp.arange(0, pitch, resolution),
-        jnp.arange(0, pitch, resolution),
+        jnp.arange(0.5 * resolution, pitch, resolution),
+        jnp.arange(0.5 * resolution, pitch, resolution),
         indexing="ij",
     )
     return (jnp.sqrt((x - pitch / 2) ** 2 + y**2) < diameter / 2) | (

--- a/examples/microlens_array.py
+++ b/examples/microlens_array.py
@@ -150,8 +150,8 @@ def circle_density(
 ) -> jnp.ndarray:
     """Generates the density array for a centered circular feature."""
     x, y = jnp.meshgrid(
-        jnp.arange(0, grid_shape[0]) / grid_shape[0] * pitch,
-        jnp.arange(0, grid_shape[1]) / grid_shape[1] * pitch,
+        jnp.arange(0.5, grid_shape[0]) / grid_shape[0] * pitch,
+        jnp.arange(0.5, grid_shape[1]) / grid_shape[1] * pitch,
         indexing="ij",
     )
     r = jnp.sqrt((x - pitch / 2) ** 2 + (y - pitch / 2) ** 2)

--- a/examples/uled.py
+++ b/examples/uled.py
@@ -171,11 +171,8 @@ def simulate_uled(
     s_matrix_before_source = s_matrices_interior_before_source[-1][0]
     s_matrix_after_source = s_matrices_interior_after_source[-1][0]
 
-    # TODO: update the locations and remove the shift by `resolution`. Requires
-    # updating regression test values.
     dipole_locations = [
-        (pitch / 2 - resolution, pitch / 2 + offset * epi_diameter - resolution)
-        for offset in dipole_y_offset
+        (pitch / 2, pitch / 2 + offset * epi_diameter) for offset in dipole_y_offset
     ]
     dipoles = fmmax.gaussian_source(
         fwhm=jnp.asarray(dipole_fwhm),
@@ -305,17 +302,13 @@ def uled_structure(
     # Generate the permittivity for the cross section below the epi
     # structure, including only the metal and the passivation.
     outer_circle_diameter = epi_diameter + thickness_passivation * 2
-    inside_outer_circle = circle_mask(
-        pitch, outer_circle_diameter, resolution, x_offset=0, y_offset=0
-    )
+    inside_outer_circle = circle_mask(pitch, outer_circle_diameter, resolution)
     permittivity_cross_section_passivation_only = jnp.where(
         inside_outer_circle, permittivity_passivation, permittivity_metal
     )
 
     # Permittivity for the cross section also including the epi.
-    inside_inner_circle = circle_mask(
-        pitch, epi_diameter, resolution, x_offset=0, y_offset=0
-    )
+    inside_inner_circle = circle_mask(pitch, epi_diameter, resolution)
     permittivity_cross_section_epi = jnp.where(
         inside_inner_circle,
         permittivity_epi,
@@ -358,16 +351,14 @@ def circle_mask(
     pitch: float,
     diameter: float,
     resolution: float,
-    x_offset: float,
-    y_offset: float,
 ) -> jnp.ndarray:
     """Returns a mask that is `True` for a centered circular feature."""
     x, y = jnp.meshgrid(
-        jnp.arange(-pitch / 2 + resolution / 2, pitch / 2, resolution),
-        jnp.arange(-pitch / 2 + resolution / 2, pitch / 2, resolution),
+        jnp.arange(resolution / 2, pitch, resolution),
+        jnp.arange(resolution / 2, pitch, resolution),
         indexing="ij",
     )
-    distance = jnp.sqrt((x - x_offset) ** 2 + (y - y_offset) ** 2)
+    distance = jnp.sqrt((x - pitch / 2) ** 2 + (y - pitch / 2) ** 2)
     return distance < diameter / 2
 
 

--- a/src/fmmax/_orig/basis.py
+++ b/src/fmmax/_orig/basis.py
@@ -189,8 +189,8 @@ def unit_cell_coordinates(
     j_stop = num_unit_cells[1] * shape[1]
     i, j = tuple(
         jnp.meshgrid(
-            jnp.arange(0, i_stop) / shape[0],
-            jnp.arange(0, j_stop) / shape[1],
+            jnp.arange(0.5, i_stop) / shape[0],
+            jnp.arange(0.5, j_stop) / shape[1],
             indexing="ij",
         )
     )

--- a/src/fmmax/_orig/fft.py
+++ b/src/fmmax/_orig/fft.py
@@ -30,7 +30,7 @@ def fourier_convolution_matrix(
     """
     basis.validate_shape_for_expansion(x.shape, expansion)
 
-    x_fft = _fft2(x, axes=(-2, -1), norm="backward", centered_coordinates=True)
+    x_fft = _fft2(x, axes=(-2, -1), norm="backward")
     x_fft /= jnp.prod(jnp.asarray(x.shape[-2:])).astype(x.dtype)
     idx = _standard_toeplitz_indices(expansion)
     return x_fft[..., idx[..., 0], idx[..., 1]]
@@ -73,7 +73,7 @@ def fft(
     axes: Tuple[int, int] = utils.absolute_axes(axes, x.ndim)  # type: ignore[no-redef]
     basis.validate_shape_for_expansion(tuple([x.shape[ax] for ax in axes]), expansion)
 
-    x_fft = _fft2(x, axes=axes, norm="forward", centered_coordinates=True)
+    x_fft = _fft2(x, axes=axes, norm="forward")
 
     leading_dims = len(x.shape[: axes[0]])
     trailing_dims = len(x.shape[axes[1] + 1 :])
@@ -124,7 +124,6 @@ def ifft(
         x,
         axes=(leading_dims, leading_dims + 1),
         norm="forward",
-        centered_coordinates=True,
     )
 
 

--- a/tests/examples/test_crystal.py
+++ b/tests/examples/test_crystal.py
@@ -33,9 +33,11 @@ class CrystalDipoleTest(unittest.TestCase):
         self.assertSequenceEqual(ex.shape, hy.shape)
         self.assertSequenceEqual(ex.shape, hz.shape)
 
-        onp.testing.assert_allclose(onp.mean(onp.abs((ex, ey, ez))), 4.64785, rtol=1e-4)
         onp.testing.assert_allclose(
-            onp.mean(onp.abs((hx, hy, hz))), 2.606728, rtol=1e-4
+            onp.mean(onp.abs((ex, ey, ez))), 4.764171, rtol=1e-4
+        )
+        onp.testing.assert_allclose(
+            onp.mean(onp.abs((hx, hy, hz))), 2.640133, rtol=1e-4
         )
 
 
@@ -60,10 +62,10 @@ class CrystalGaussianBeamTest(unittest.TestCase):
         self.assertSequenceEqual(ex.shape, hz.shape)
 
         onp.testing.assert_allclose(
-            onp.mean(onp.abs((ex, ey, ez))), 0.268458, rtol=1e-4
+            onp.mean(onp.abs((ex, ey, ez))), 0.268013, rtol=1e-4
         )
         onp.testing.assert_allclose(
-            onp.mean(onp.abs((hx, hy, hz))), 0.187563, rtol=1e-4
+            onp.mean(onp.abs((hx, hy, hz))), 0.186873, rtol=1e-4
         )
 
     def test_broadband_regression(self):
@@ -99,7 +101,7 @@ class CrystalGaussianBeamTest(unittest.TestCase):
                     )
                 )
             ),
-            0.268458,
+            0.268013,
             rtol=1e-4,
         )
         onp.testing.assert_allclose(
@@ -112,6 +114,6 @@ class CrystalGaussianBeamTest(unittest.TestCase):
                     )
                 )
             ),
-            0.187563,
+            0.186873,
             rtol=1e-4,
         )

--- a/tests/examples/test_metal_dipole.py
+++ b/tests/examples/test_metal_dipole.py
@@ -29,8 +29,8 @@ class MetalDipoleTest(unittest.TestCase):
         self.assertSequenceEqual(ex.shape, hz.shape)
 
         onp.testing.assert_allclose(
-            onp.mean(onp.abs((ex, ey, ez))), 4.712292, rtol=1e-4
+            onp.mean(onp.abs((ex, ey, ez))), 4.708408, rtol=1e-4
         )
         onp.testing.assert_allclose(
-            onp.mean(onp.abs((hx, hy, hz))), 7.276852, rtol=1e-4
+            onp.mean(onp.abs((hx, hy, hz))), 7.275805, rtol=1e-4
         )

--- a/tests/examples/test_microlens_array.py
+++ b/tests/examples/test_microlens_array.py
@@ -30,9 +30,5 @@ class MicrolensArrayTest(unittest.TestCase):
         self.assertSequenceEqual(ex.shape, hy.shape)
         self.assertSequenceEqual(ex.shape, hz.shape)
 
-        onp.testing.assert_allclose(
-            onp.mean(onp.abs((ex, ey, ez))), 0.324081, rtol=1e-4
-        )
-        onp.testing.assert_allclose(
-            onp.mean(onp.abs((hx, hy, hz))), 0.390007, rtol=1e-4
-        )
+        onp.testing.assert_allclose(onp.mean(onp.abs((ex, ey, ez))), 0.32432, rtol=1e-4)
+        onp.testing.assert_allclose(onp.mean(onp.abs((hx, hy, hz))), 0.38995, rtol=1e-4)

--- a/tests/examples/test_uled.py
+++ b/tests/examples/test_uled.py
@@ -32,7 +32,7 @@ class MicroLedTest(unittest.TestCase):
         with self.subTest("extraction efficiency"):
             onp.testing.assert_allclose(
                 extraction_efficiency,
-                [0.495602, 0.495602, 0.227267],
+                [0.496093, 0.496177, 0.247206],
                 atol=1e-3,
             )
 
@@ -41,9 +41,9 @@ class MicroLedTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(efields) ** 2, axis=(1, 2, 3, 4, 5)),
                 [
-                    [62.21017, 8.363873, 2.796478],
-                    [8.363873, 62.21017, 2.796478],
-                    [14.590969, 14.590969, 9.568378],
+                    [64.48044, 8.389313, 2.740909],
+                    [8.386348, 64.499756, 2.740864],
+                    [15.16424, 15.166618, 8.501956],
                 ],
                 rtol=1e-3,
             )
@@ -53,9 +53,9 @@ class MicroLedTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 jnp.mean(jnp.abs(hfields) ** 2, axis=(1, 2, 3, 4, 5)),
                 [
-                    [34.4182, 393.426243, 37.876831],
-                    [393.426243, 34.4182, 37.876831],
-                    [142.142214, 142.142214, 1.321144],
+                    [35.596813, 411.6974, 33.963284],
+                    [411.5761, 35.610237, 33.963463],
+                    [141.883, 141.92323, 1.209434],
                 ],
                 rtol=1e-3,
             )

--- a/tests/fmmax/test_basis.py
+++ b/tests/fmmax/test_basis.py
@@ -263,9 +263,9 @@ class InPlaneWavevectorTest(unittest.TestCase):
 class UnitCellCoordiantesTest(unittest.TestCase):
     @parameterized.expand(
         [
-            [(1, 1), (3, 2), (0, 1, 2), (0, 1)],
-            [(1, 1), (4, 3), (0, 1, 2, 3), (0, 1, 2)],
-            [(2, 2), (2, 1), (0, 0.5, 1.0, 1.5), (0, 0.5)],
+            [(1, 1), (3, 2), (0.5, 1.5, 2.5), (0.5, 1.5)],
+            [(1, 1), (4, 3), (0.5, 1.5, 2.5, 3.5), (0.5, 1.5, 2.5)],
+            [(2, 2), (2, 1), (0.25, 0.75, 1.25, 1.75), (0.25, 0.75)],
         ]
     )
     def test_values_match_expected(self, shape, num_unit_cells, expected_x, expected_y):

--- a/tests/fmmax/test_fmm.py
+++ b/tests/fmmax/test_fmm.py
@@ -429,13 +429,19 @@ class FourierMatrixBatchMatchesSingleTest(unittest.TestCase):
         scale = jnp.arange(1, 5)[:, jnp.newaxis, jnp.newaxis]
         permittivity = 1 + circle * scale
 
+        expansion = basis.generate_expansion(
+            primitive_lattice_vectors=PRIMITIVE_LATTICE_VECTORS,
+            approximate_num_terms=100,
+            truncation=basis.Truncation.CIRCULAR,
+        )
+
         (
             batch_inverse_z_permittivity_matrix,
             batch_z_permittivity_matrix,
             batch_transverse_permittivity_matrix,
             batch_tangent_vector_field,
         ) = fmm._fourier_matrices_patterned_isotropic_media(
-            PRIMITIVE_LATTICE_VECTORS, permittivity, EXPANSION, formulation
+            PRIMITIVE_LATTICE_VECTORS, permittivity, expansion, formulation
         )
 
         for i, p in enumerate(permittivity):
@@ -445,7 +451,7 @@ class FourierMatrixBatchMatchesSingleTest(unittest.TestCase):
                 transverse_permittivity_matrix,
                 tangent_vector_field,
             ) = fmm._fourier_matrices_patterned_isotropic_media(
-                PRIMITIVE_LATTICE_VECTORS, p, EXPANSION, formulation
+                PRIMITIVE_LATTICE_VECTORS, p, expansion, formulation
             )
             onp.testing.assert_allclose(
                 inverse_z_permittivity_matrix,
@@ -483,6 +489,12 @@ class FourierMatrixBatchMatchesSingleTest(unittest.TestCase):
         permeabilities = 1 + circle * permeabilities_scale
         assert permittivities.shape == (5, 6, 50, 50)
 
+        expansion = basis.generate_expansion(
+            primitive_lattice_vectors=PRIMITIVE_LATTICE_VECTORS,
+            approximate_num_terms=100,
+            truncation=basis.Truncation.CIRCULAR,
+        )
+
         (
             batch_inverse_z_permittivity_matrix,
             batch_z_permittivity_matrix,
@@ -495,7 +507,7 @@ class FourierMatrixBatchMatchesSingleTest(unittest.TestCase):
             PRIMITIVE_LATTICE_VECTORS,
             tuple(permittivities),
             tuple(permeabilities),
-            EXPANSION,
+            expansion,
             formulation,
             permittivities[0, ...],
         )
@@ -513,7 +525,7 @@ class FourierMatrixBatchMatchesSingleTest(unittest.TestCase):
                 PRIMITIVE_LATTICE_VECTORS,
                 tuple(permittivities[:, i, ...]),
                 tuple(permeabilities[:, i, ...]),
-                EXPANSION,
+                expansion,
                 formulation,
                 permittivities[0, i, ...],
             )
@@ -528,7 +540,8 @@ class FourierMatrixBatchMatchesSingleTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 transverse_permittivity_matrix,
                 batch_transverse_permittivity_matrix[i, ...],
-                atol=1e-15,
+                atol=1e-12,
+                rtol=1e-6,
             )
             onp.testing.assert_allclose(
                 inverse_z_permeability_matrix,
@@ -541,7 +554,8 @@ class FourierMatrixBatchMatchesSingleTest(unittest.TestCase):
             onp.testing.assert_allclose(
                 transverse_permeability_matrix,
                 batch_transverse_permeability_matrix[i, ...],
-                atol=1e-15,
+                atol=1e-12,
+                rtol=1e-6,
             )
             if formulation != fmm.Formulation.FFT:
                 onp.testing.assert_allclose(

--- a/tests/fmmax/test_grad_finite_difference.py
+++ b/tests/fmmax/test_grad_finite_difference.py
@@ -15,15 +15,15 @@ from fmmax import basis, fields, fmm, scattering
 
 
 def gaussian_permittivity_fn(x0, y0, dim):
-    x = jnp.arange(0, dim)[:, jnp.newaxis] / dim - x0
-    y = jnp.arange(0, dim)[jnp.newaxis, :] / dim - y0
+    x = jnp.arange(0.5, dim)[:, jnp.newaxis] / dim - x0
+    y = jnp.arange(0.5, dim)[jnp.newaxis, :] / dim - y0
     return 1 + 10 * jnp.exp((-(x**2) - y**2) * 25)
 
 
 class FiniteDifferenceGradientTest(unittest.TestCase):
     @parameterized.expand(
         [
-            (fmm.Formulation.FFT, 3e-3),
+            (fmm.Formulation.FFT, 4e-3),
             (fmm.Formulation.JONES_DIRECT, 1e-2),
             (fmm.Formulation.JONES_DIRECT_FOURIER, 1e-2),
             (fmm.Formulation.POL, 2e-2),

--- a/tests/fmmax/test_pml.py
+++ b/tests/fmmax/test_pml.py
@@ -184,11 +184,13 @@ class GaussianBeamInPMLDecayTest(unittest.TestCase):
             use_pml=False
         )
         # With or without PML, the incident power is identical.
-        onp.testing.assert_allclose(power_at_end, power_at_end_no_pml, rtol=1e-2)
+        onp.testing.assert_allclose(
+            power_at_end, power_at_end_no_pml, rtol=1e-2, atol=0.001
+        )
         # With no PML, the power at the end is equal to the power at the start.
         onp.testing.assert_allclose(power_at_end_no_pml, power_at_start_no_pml)
-        # With PML, the power at the start is decayed by at least 1e4.
-        self.assertGreater(onp.abs(power_at_end), 1e4 * onp.abs(power_at_start))
+        # With PML, the power at the start is decayed by at least 1e3.
+        self.assertGreater(onp.abs(power_at_end), 1e3 * onp.abs(power_at_start))
 
 
 class DipoleFieldsInPMLDecayTest(unittest.TestCase):

--- a/tests/fmmax/test_symmetry.py
+++ b/tests/fmmax/test_symmetry.py
@@ -1,0 +1,97 @@
+"""Tests that fields have the expected symmetry.
+
+Copyright (c) Martin F. Schubert
+"""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as onp
+
+from fmmax import basis, fields, fmm, scattering, sources
+
+
+class SymmetryTest(unittest.TestCase):
+    def test_fields_have_expected_symmetry(self):
+        # Test that a symmetric permittivity distribution and a centered source yield
+        # fields with corresponding symmetry.
+        primitive_lattice_vectors = basis.LatticeVectors(u=basis.X, v=basis.Y)
+        x, y = basis.unit_cell_coordinates(
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            shape=(10, 10),
+            num_unit_cells=(1, 1),
+        )
+        permittivity = jnp.where(
+            jnp.sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2) < 0.3, 2.0, 1.0
+        )
+
+        # Ensure that permittivity is symmetric.
+        onp.testing.assert_array_equal(permittivity, onp.rot90(permittivity, 1))
+        onp.testing.assert_array_equal(permittivity, onp.rot90(permittivity, 2))
+        onp.testing.assert_array_equal(permittivity, onp.rot90(permittivity, 3))
+
+        in_plane_wavevector = jnp.zeros((2,))
+        expansion = basis.generate_expansion(
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            approximate_num_terms=64,
+        )
+
+        solve_result = fmm.eigensolve_isotropic_media(
+            wavelength=jnp.asarray(0.55),
+            in_plane_wavevector=in_plane_wavevector,
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            permittivity=permittivity,
+            expansion=expansion,
+            formulation=fmm.Formulation.FFT,
+        )
+
+        s_matrix = scattering.stack_s_matrix([solve_result], layer_thicknesses=[1.0])
+        dipole = sources.dirac_delta_source(
+            location=jnp.asarray([[0.5, 0.5]]),
+            in_plane_wavevector=in_plane_wavevector,
+            primitive_lattice_vectors=primitive_lattice_vectors,
+            expansion=expansion,
+        )
+        zeros = jnp.zeros_like(dipole)
+        jx = jnp.concatenate([dipole, zeros, zeros], axis=-1)
+        jy = jnp.concatenate([zeros, dipole, zeros], axis=-1)
+        jz = jnp.concatenate([zeros, zeros, dipole], axis=-1)
+
+        (
+            bwd_amplitude_0_end,
+            fwd_amplitude_before_start,
+            bwd_amplitude_before_end,
+            fwd_amplitude_after_start,
+            bwd_amplitude_after_end,
+            fwd_amplitude_N_end,
+        ) = sources.amplitudes_for_source(
+            jx=jx,
+            jy=jy,
+            jz=jz,
+            s_matrix_before_source=s_matrix,
+            s_matrix_after_source=s_matrix,
+        )
+
+        electric_field, magnetic_field = fields.fields_from_wave_amplitudes(
+            forward_amplitude=jnp.zeros_like(bwd_amplitude_0_end),
+            backward_amplitude=bwd_amplitude_0_end,
+            layer_solve_result=solve_result,
+        )
+
+        (ex, ey, ez), (hx, hy, hz), (x, y) = fields.fields_on_grid(
+            electric_field=electric_field,
+            magnetic_field=magnetic_field,
+            layer_solve_result=solve_result,
+            shape=permittivity.shape,
+        )
+
+        # Fields for x-oriented dipole are 180 degree rotation symmetric
+        onp.testing.assert_allclose(ex[:, :, 0], onp.rot90(ex[:, :, 0], 2), rtol=2e-3)
+
+        # Fields for y-oriented dipole are 180 degree rotation symmetric
+        onp.testing.assert_allclose(ey[:, :, 1], onp.rot90(ey[:, :, 1], 2), rtol=2e-3)
+
+        # Fields for z-oriented dipole are 90 degree rotation symmetric
+        onp.testing.assert_allclose(ez[:, :, 2], onp.rot90(ez[:, :, 2], 1), rtol=2e-3)
+        onp.testing.assert_allclose(ez[:, :, 2], onp.rot90(ez[:, :, 2], 2), rtol=2e-3)
+        onp.testing.assert_allclose(ez[:, :, 2], onp.rot90(ez[:, :, 2], 3), rtol=2e-3)


### PR DESCRIPTION
This PR adjusts the unit cell coordinates so that  the first element of an array defined on the unit cell is at $(\mathbf{du} / 2 + \mathbf{dv} / 2)$ rather than $\mathbf{0}$. This requires changes to reference values in regression tests that depend upon the precise definition of unit cell coordinates.